### PR TITLE
Add docstrings to suite.py and utils.py

### DIFF
--- a/sworkflow/suite.py
+++ b/sworkflow/suite.py
@@ -6,34 +6,67 @@ import subprocess as sp
 import graphviz
 from . import utils
 
-"""
-A python interface to script slurm dependency.
-
-Specify dependencies between tasks as a python dictionary mapping.
-Tasks are to be defined in a separate mapping.
-
-task dependency example:
-
-dependency = {
-    'D': 'afterany:C:B',
-    'C': 'afterok:A',
-    'B': 'after:A',
-  }
-
-jobs = {
-    'A': 'sleep.sh',
-    'B': 'sbatch --parsable sleep.sh',
-    'C': 'sbatch --mem 40G sleep.sh'
-}
-
-s = Suite(dependency, jobs)
-"""
-
 default_task = 'sbatch --wrap="sleep 2"'
 
 
 class Suite:
+    """Orchestrates a Slurm job workflow defined as a dependency graph.
+
+    Holds the dependency relationships between jobs, their commands, and the
+    Slurm job IDs captured after submission. Jobs are submitted in topological
+    order so each job's dependencies are already running or complete when it
+    starts.
+
+    Attributes:
+        dependency: Maps each job name to a Slurm dependency string, e.g.
+            ``{"train": "afterok:preprocess"}``. Jobs not listed here are
+            treated as roots with no dependencies.
+        jobs: Maps each job name to the shell command or script path used to
+            submit it. ``sbatch`` and ``--parsable`` are injected automatically
+            if absent.
+        job_ids: Maps each job name to its Slurm job ID string, populated
+            after calling :meth:`submit`.
+        job_template: Stores the fully-formed sbatch command strings built by
+            :meth:`prepare_jobs`, with dependency flags and job-ID placeholders.
+        status: Maps each job name to its Slurm state string (e.g. ``"RUNNING"``),
+            populated by :meth:`update_status`.
+        filename: Path to the YAML file this suite was loaded from or will be
+            saved to.
+
+    Example::
+
+        dependency = {
+            'D': 'afterany:C:B',
+            'C': 'afterok:A',
+            'B': 'after:A',
+        }
+
+        jobs = {
+            'A': 'sleep.sh',
+            'B': 'sbatch --mem 40G sleep.sh',
+            'C': 'sbatch --parsable sleep.sh',
+        }
+
+        s = Suite(dependency, jobs)
+        s.visualize()
+        s.submit()
+    """
+
     def __init__(self, dependency: dict, jobs: dict = None, job_ids: dict = None):
+        """Initialize a Suite.
+
+        Args:
+            dependency: Maps job names to Slurm dependency strings. Each value
+                follows Slurm's ``--dependency`` syntax, e.g.
+                ``"afterok:preprocess"`` or ``"afterok:B:C"`` for multiple
+                predecessors.
+            jobs: Maps job names to the command or script used to submit them.
+                If ``sbatch`` is absent from a command it is prepended
+                automatically. Defaults to an empty dict.
+            job_ids: Pre-populated mapping of job name to Slurm job ID, e.g.
+                when loading a previously submitted workflow from YAML.
+                Defaults to an empty dict.
+        """
         self.dependency = dependency
         self.jobs = jobs or {}
         self.job_ids = job_ids or {}
@@ -43,6 +76,18 @@ class Suite:
 
     @classmethod
     def load_yaml(cls, filename):
+        """Load a workflow from a YAML file.
+
+        The file must contain a ``dependency`` key. ``jobs`` and ``job_ids``
+        are optional and default to empty dicts if absent.
+
+        Args:
+            filename: Path to the YAML workflow file.
+
+        Returns:
+            A new :class:`Suite` instance with :attr:`filename` set to the
+            given path.
+        """
         d = utils.load_yaml(filename)
         dependency = d["dependency"]
         jobs = d.get("jobs", {})
@@ -52,12 +97,34 @@ class Suite:
         return c
 
     def save_yaml(self, filename, include_job_ids=True):
+        """Serialize the workflow to a YAML file.
+
+        Args:
+            filename: Destination path for the YAML file.
+            include_job_ids: When ``True`` (default), the ``job_ids`` section
+                is written so that a submitted workflow can be reloaded later
+                to check status.
+        """
         d = {"dependency": self.dependency, "jobs": self.jobs}
         if include_job_ids:
             d["job_ids"] = self.job_ids
         utils.save_yaml(d, filename)
 
     def prepare_jobs(self):
+        """Build the sbatch command strings for all jobs.
+
+        For each job, this method ensures:
+
+        - ``sbatch`` is the first token.
+        - ``--parsable`` appears immediately after ``sbatch`` so the job ID
+          is the sole output of the command.
+        - ``--dependency=<condition>:{id}:{id}...`` is injected for jobs that
+          have predecessors, using ``{job_name}`` placeholders that are
+          resolved to real Slurm IDs at submission time.
+
+        Results are stored in :attr:`job_template`. Jobs not present in
+        :attr:`jobs` receive the default command ``sbatch --wrap="sleep 2"``.
+        """
         dependency = self.dependency
         ordering = utils.task_ordering(dependency)
         dependency_placeholder = utils.as_placeholder(dependency)
@@ -78,6 +145,23 @@ class Suite:
         self.job_template.update(result)
 
     def submit(self, dry_run=False):
+        """Submit all jobs to Slurm in dependency order.
+
+        Calls :meth:`prepare_jobs`, then iterates jobs in topological order,
+        substituting captured job IDs into dependency placeholders before each
+        ``sbatch`` call. The resulting job IDs are written back to
+        :attr:`job_ids` and the workflow is saved to :attr:`filename` (defaulting
+        to ``"submit.yaml"``).
+
+        Args:
+            dry_run: When ``True``, commands are printed to stdout instead of
+                executed and fake random job IDs are used. Useful for
+                validating the generated sbatch commands before real submission.
+
+        Returns:
+            :attr:`job_ids` dict mapping each job name to its Slurm job ID
+            string (or a fake ID string in dry-run mode).
+        """
         func = (sp.check_output, utils.check_output)[dry_run]
         self.filename = self.filename or "submit.yaml"
         filename = self.filename
@@ -97,6 +181,20 @@ class Suite:
         return self.job_ids
 
     def graph(self, rankdir="LR"):
+        """Build a Graphviz directed graph of the workflow.
+
+        Each node is labeled with the job name, its Slurm job ID (if
+        submitted), and its current status (if available). Edges point from
+        each prerequisite to its dependent job. Calls :meth:`update_status`
+        internally so status information is current.
+
+        Args:
+            rankdir: Graphviz layout direction. One of ``"LR"`` (left-right,
+                default), ``"RL"``, ``"TB"``, or ``"BT"``.
+
+        Returns:
+            A :class:`graphviz.Digraph` instance.
+        """
         self.update_status()
         d = utils.as_dict(self.dependency)
         ordering = utils.task_ordering(self.dependency)
@@ -112,6 +210,28 @@ class Suite:
         return g
 
     def visualize(self, rankdir="LR", as_ascii=True, view_pdf=True):
+        """Render the workflow dependency graph.
+
+        Behaviour depends on the execution environment:
+
+        - **Jupyter notebook**: returns the :class:`graphviz.Digraph` object
+          directly so Jupyter renders it inline.
+        - **Terminal (default)**: converts the graph to ASCII art via an
+          external HTTP API and prints it.
+        - **PDF mode** (``as_ascii=False``): renders a PDF with Graphviz and
+          optionally opens it in the default viewer.
+
+        Args:
+            rankdir: Graph layout direction passed to :meth:`graph`.
+            as_ascii: When ``True`` (default), render ASCII art in the
+                terminal. When ``False``, produce a PDF file.
+            view_pdf: When ``as_ascii=False``, automatically open the rendered
+                PDF. Has no effect in ASCII mode.
+
+        Returns:
+            The :class:`graphviz.Digraph` instance, or ``None`` in ASCII/PDF
+            mode (side-effects only).
+        """
         g = self.graph(rankdir=rankdir)
         if utils.in_jupyter():
             return g
@@ -121,6 +241,18 @@ class Suite:
         g.render(f"slurmviz-{str(random.randint(0, 20))}", view=view_pdf)
 
     def update_status(self):
+        """Query Slurm for the current state of all submitted jobs.
+
+        Uses ``sacct`` to fetch job states for every ID in :attr:`job_ids`.
+        Slurm array jobs (whose IDs contain ``_``) are collapsed into a
+        compact summary string (e.g. ``"2C-1R"`` for 2 completed, 1 running).
+        Results are stored in :attr:`status`.
+
+        Returns:
+            A list of ``(job_name, job_id, state)`` tuples for each job.
+            Returns an empty list if :attr:`job_ids` is empty or if ``sacct``
+            is not available on the current system.
+        """
         sacct_cmd = 'sacct -n -P --format="jobid,state" -j {}'
         result = []
         if not self.job_ids:

--- a/sworkflow/utils.py
+++ b/sworkflow/utils.py
@@ -18,8 +18,22 @@ keywords = {
 
 
 def as_dict(dependency):
-    """
-    task dependency mapping stripping off keywords
+    """Return a predecessor-list mapping stripped of Slurm dependency keywords.
+
+    Transforms the raw dependency dict into a form suitable for graph
+    construction and topological sorting. Slurm condition keywords (e.g.
+    ``afterok``) are discarded; only the job names remain.
+
+    Handles Slurm job array suffixes: ``+offset`` (e.g. ``jobA+1``) and
+    ``_taskid`` (e.g. ``jobA_10``) are stripped, leaving only the base name.
+
+    Args:
+        dependency: Maps each job name to a Slurm dependency string such as
+            ``"afterok:preprocess"`` or ``"afterok:B:C"``.
+
+    Returns:
+        Dict mapping each job name to a list of its predecessor job names,
+        e.g. ``{"train": ["preprocess"], "postprocess": ["train"]}``.
     """
     names = defaultdict(list)
     pattern = re.compile("[,?:]")
@@ -37,6 +51,21 @@ def as_dict(dependency):
 
 
 def as_tuple(dependency):
+    """Parse dependency strings into ``[keyword, dep1, dep2, ...]`` lists.
+
+    Unlike :func:`as_dict`, this preserves the Slurm condition keyword as the
+    first element of each list. Handles comma-separated compound conditions
+    (``afterok:A,afternotok:B``) and the ``?`` separator for alternative
+    conditions.
+
+    Args:
+        dependency: Maps each job name to a Slurm dependency string.
+
+    Returns:
+        Dict mapping each job name to a flat list starting with the condition
+        keyword followed by predecessor names, e.g.
+        ``{"train": ["afterok", "preprocess"]}``.
+    """
     names = defaultdict(list)
     pattern = re.compile("[,?]")
     for name, value in dependency.items():
@@ -55,6 +84,21 @@ def as_tuple(dependency):
 
 
 def _formatted(job_str: str) -> str:
+    """Convert a single dependency segment into a ``format_map``-ready string.
+
+    Replaces each job name with a ``{name}`` placeholder while preserving the
+    Slurm condition keyword and any array suffixes (``+offset`` or ``_taskid``).
+
+    For example, ``"afterok:A:B"`` becomes ``"afterok:{A}:{B}"``, and
+    ``"afterok:A+1"`` becomes ``"afterok:{A}+1"``.
+
+    Args:
+        job_str: A single colon-separated dependency segment such as
+            ``"afterok:preprocess"`` or ``"afterok:B:C"``.
+
+    Returns:
+        The same segment with job names wrapped in curly braces.
+    """
     keyword, *names = job_str.split(":")
     parts = [keyword]
     for name in names:
@@ -71,6 +115,25 @@ def _formatted(job_str: str) -> str:
 
 
 def as_placeholder(dependency):
+    """Transform a dependency dict so job names become ``{name}`` placeholders.
+
+    Converts all job name references in the dependency values to Python
+    ``str.format_map`` placeholders. The result is used in :meth:`Suite.submit`
+    to interpolate real Slurm job IDs at submission time.
+
+    For example, ``{"train": "afterok:preprocess"}`` becomes
+    ``{"train": "afterok:{preprocess}"}``.
+
+    Handles comma-separated (``afterok:A,afternotok:B``) and ``?``-separated
+    alternative conditions.
+
+    Args:
+        dependency: Maps each job name to a Slurm dependency string.
+
+    Returns:
+        Dict with the same keys, but job name tokens replaced by
+        ``{job_name}`` placeholders.
+    """
     result = {}
     for name, value in dependency.items():
         comma_parts = []
@@ -82,26 +145,69 @@ def as_placeholder(dependency):
 
 
 def task_ordering(dependency):
-    """
-    ordering of tasks
+    """Return jobs in a valid submission order respecting all dependencies.
+
+    Uses :class:`graphlib.TopologicalSorter` on the predecessor graph produced
+    by :func:`as_dict`. Root jobs (those with no predecessors) appear first.
+
+    Args:
+        dependency: Maps each job name to a Slurm dependency string.
+
+    Returns:
+        List of job name strings in topological order.
+
+    Raises:
+        graphlib.CycleError: If the dependency graph contains a cycle.
     """
     d = as_dict(dependency)
     return list(TopologicalSorter(d).static_order())
 
 
 def load_yaml(filename):
+    """Read a YAML file and return its contents as a Python object.
+
+    Args:
+        filename: Path to the YAML file.
+
+    Returns:
+        The parsed YAML content (typically a dict).
+    """
     with open(filename, "r") as fid:
         d = yaml.safe_load(fid)
     return d
 
 
 def save_yaml(content, filename):
+    """Write a Python object to a YAML file.
+
+    Args:
+        content: The object to serialize (typically a dict).
+        filename: Destination file path.
+    """
     with open(filename, "w") as fid:
         yaml.safe_dump(content, fid)
     return
 
 
 def check_output(task, *args, **kwargs):
+    """Dry-run replacement for ``subprocess.check_output``.
+
+    Prints the command to stdout instead of executing it, then returns a
+    random integer encoded as bytes to simulate a Slurm job ID.
+
+    If ``task_name`` is provided via keyword argument, the output is formatted
+    as a shell assignment (``task_name=$(command ...)``), matching how a real
+    submission script would capture job IDs.
+
+    Args:
+        task: List of command tokens (the same format as
+            ``subprocess.check_output``).
+        task_name: Optional job name used to format the printed output as a
+            shell variable assignment.
+
+    Returns:
+        A fake job ID as ``bytes``, e.g. ``b"742"``.
+    """
     task_name = kwargs.get("task_name", None)
     if task_name:
         print(f"{task_name}=$({shlex.join(task)})")
@@ -111,6 +217,18 @@ def check_output(task, *args, **kwargs):
 
 
 def dot_to_ascii(g):
+    """Render a Graphviz graph as ASCII art via an external HTTP API.
+
+    Sends the graph's DOT source to ``dot-to-ascii.ggerganov.com`` and prints
+    the resulting ASCII diagram to stdout.
+
+    Args:
+        g: A :class:`graphviz.Digraph` (or similar) whose ``__str__`` produces
+            valid DOT syntax.
+
+    Returns:
+        The ASCII art string returned by the API.
+    """
     url = "https://dot-to-ascii.ggerganov.com/dot-to-ascii.php"
     params = {"boxart": 1, "src": str(g)}
     res = requests.get(url, params=params).text
@@ -119,6 +237,16 @@ def dot_to_ascii(g):
 
 
 def in_jupyter():
+    """Return ``True`` if the current process is running inside a Jupyter kernel.
+
+    Distinguishes Jupyter notebooks from terminal IPython sessions by checking
+    the IPython shell class name.
+
+    Returns:
+        ``True`` when running in a Jupyter notebook or JupyterLab cell,
+        ``False`` otherwise (including plain Python, terminal IPython, and
+        environments where IPython is not installed).
+    """
     try:
         from IPython.core import getipython
     except ImportError:
@@ -132,11 +260,37 @@ def in_jupyter():
 
 
 class Default(dict):
+    """A dict subclass that returns ``"{key}"`` for missing keys.
+
+    Used with :meth:`str.format_map` so that unresolved job-name placeholders
+    are left intact in the command string rather than raising a ``KeyError``.
+    This allows :meth:`Suite.submit` to build dependency flags progressively as
+    each job ID becomes known.
+    """
+
     def __missing__(self, key):
+        """Return ``"{key}"`` so unresolved placeholders survive ``format_map``."""
         return f"{{{key}}}"
 
 
 def parse_array_status(mapping):
+    """Collapse Slurm array job entries into a per-parent summary.
+
+    Slurm reports array tasks as separate rows with IDs like ``12345_1``,
+    ``12345_2``, etc. This function groups them by parent job ID and produces
+    a compact state summary such as ``"2C-1R"`` (2 COMPLETED, 1 RUNNING).
+
+    Only entries whose ID contains ``_`` but not ``.`` are treated as array
+    tasks; all others are ignored.
+
+    Args:
+        mapping: Dict mapping Slurm job ID strings to state strings, as
+            returned by parsing ``sacct`` output.
+
+    Returns:
+        Dict mapping each parent array job ID to a summary string like
+        ``"3C-1F"`` where each segment is ``<count><first-letter-of-state>``.
+    """
     result = {}
     array = defaultdict(Counter)
     for job_id, state in mapping.items():


### PR DESCRIPTION
## Summary
- Add Google-style docstrings to the `Suite` class and all 7 of its methods in `suite.py`
- Add docstrings to all 12 functions/classes in `utils.py`, including the internal `_formatted` helper and the `Default` dict subclass
- No logic changes — documentation only

## Test plan
- [x] AST check confirms all symbols are documented
- [x] No existing behaviour changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)