### PR TITLE
Add pytest test suite (55 tests)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ graphviz
 graphlib_backport; python_version < "3.9.0"
 requests
 click
+pytest

--- a/tests/test_suite.py
+++ b/tests/test_suite.py
@@ -1,0 +1,300 @@
+import pytest
+import yaml
+from pathlib import Path
+from unittest.mock import patch, call, MagicMock
+
+from sworkflow.suite import Suite
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+SIMPLE_DEP = {"train": "afterok:preprocess", "postprocess": "afterok:train"}
+SIMPLE_JOBS = {
+    "preprocess": "preprocess.sh",
+    "train": "train.sh",
+    "postprocess": "postprocess.sh",
+}
+
+
+def make_suite(**kwargs):
+    return Suite(
+        dependency=kwargs.get("dependency", SIMPLE_DEP),
+        jobs=kwargs.get("jobs", SIMPLE_JOBS),
+        job_ids=kwargs.get("job_ids", {}),
+    )
+
+
+# ---------------------------------------------------------------------------
+# __init__
+# ---------------------------------------------------------------------------
+
+class TestSuiteInit:
+    def test_attributes_set(self):
+        s = Suite(dependency=SIMPLE_DEP, jobs=SIMPLE_JOBS, job_ids={"preprocess": "1"})
+        assert s.dependency == SIMPLE_DEP
+        assert s.jobs == SIMPLE_JOBS
+        assert s.job_ids == {"preprocess": "1"}
+
+    def test_defaults_are_empty_dicts(self):
+        s = Suite(dependency={})
+        assert s.jobs == {}
+        assert s.job_ids == {}
+        assert s.job_template == {}
+        assert s.status == {}
+        assert s.filename is None
+
+
+# ---------------------------------------------------------------------------
+# load_yaml / save_yaml
+# ---------------------------------------------------------------------------
+
+class TestYamlRoundTrip:
+    def test_roundtrip(self, tmp_path):
+        path = tmp_path / "workflow.yaml"
+        s = make_suite()
+        s.filename = str(path)
+        s.save_yaml(str(path))
+
+        loaded = Suite.load_yaml(str(path))
+        assert loaded.dependency == SIMPLE_DEP
+        assert loaded.jobs == SIMPLE_JOBS
+        assert loaded.filename == str(path)
+
+    def test_job_ids_included_by_default(self, tmp_path):
+        path = tmp_path / "workflow.yaml"
+        s = make_suite(job_ids={"preprocess": "42"})
+        s.save_yaml(str(path))
+
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        assert "job_ids" in data
+        assert data["job_ids"]["preprocess"] == "42"
+
+    def test_job_ids_excluded_when_flag_false(self, tmp_path):
+        path = tmp_path / "workflow.yaml"
+        s = make_suite(job_ids={"preprocess": "42"})
+        s.save_yaml(str(path), include_job_ids=False)
+
+        with open(path) as f:
+            data = yaml.safe_load(f)
+        assert "job_ids" not in data
+
+    def test_load_yaml_without_jobs_section(self, tmp_path):
+        path = tmp_path / "minimal.yaml"
+        path.write_text("dependency:\n  B: afterok:A\n")
+        s = Suite.load_yaml(str(path))
+        assert s.jobs == {}
+        assert s.job_ids == {}
+
+
+# ---------------------------------------------------------------------------
+# prepare_jobs
+# ---------------------------------------------------------------------------
+
+class TestPrepareJobs:
+    def test_sbatch_injected(self):
+        s = Suite(
+            dependency={"B": "afterok:A"},
+            jobs={"A": "a.sh", "B": "b.sh"},
+        )
+        s.prepare_jobs()
+        assert s.job_template["A"].startswith("sbatch")
+        assert s.job_template["B"].startswith("sbatch")
+
+    def test_parsable_injected(self):
+        s = Suite(
+            dependency={"B": "afterok:A"},
+            jobs={"A": "a.sh", "B": "b.sh"},
+        )
+        s.prepare_jobs()
+        assert "--parsable" in s.job_template["A"]
+        assert "--parsable" in s.job_template["B"]
+
+    def test_dependency_flag_injected_for_dependents(self):
+        s = Suite(
+            dependency={"B": "afterok:A"},
+            jobs={"A": "a.sh", "B": "b.sh"},
+        )
+        s.prepare_jobs()
+        assert "--dependency=afterok:{A}" in s.job_template["B"]
+
+    def test_no_dependency_flag_for_roots(self):
+        s = Suite(
+            dependency={"B": "afterok:A"},
+            jobs={"A": "a.sh", "B": "b.sh"},
+        )
+        s.prepare_jobs()
+        assert "--dependency" not in s.job_template["A"]
+
+    def test_default_command_used_for_missing_job(self):
+        s = Suite(
+            dependency={"B": "afterok:A"},
+            jobs={},  # no job definitions
+        )
+        s.prepare_jobs()
+        assert "sleep" in s.job_template["A"]
+        assert "sleep" in s.job_template["B"]
+
+    def test_sbatch_not_duplicated(self):
+        s = Suite(
+            dependency={"B": "afterok:A"},
+            jobs={"A": "sbatch a.sh", "B": "sbatch b.sh"},
+        )
+        s.prepare_jobs()
+        assert s.job_template["A"].count("sbatch") == 1
+
+
+# ---------------------------------------------------------------------------
+# submit (mocked)
+# ---------------------------------------------------------------------------
+
+class TestSubmit:
+    def _fake_check_output(self, cmd, *args, **kwargs):
+        """Return a different fake job ID for each successive call."""
+        self._call_count = getattr(self, "_call_count", 0) + 1
+        return f"{self._call_count}00".encode()
+
+    def test_job_ids_populated(self, tmp_path):
+        s = Suite(dependency=SIMPLE_DEP, jobs=SIMPLE_JOBS)
+        s.filename = str(tmp_path / "out.yaml")
+        counter = {"n": 0}
+
+        def fake_sp(cmd, *a, **kw):
+            counter["n"] += 1
+            return f"{counter['n']}00".encode()
+
+        with patch("subprocess.check_output", side_effect=fake_sp):
+            ids = s.submit()
+
+        assert set(ids.keys()) == {"preprocess", "train", "postprocess"}
+        assert all(v.isdigit() for v in ids.values())
+
+    def test_yaml_written_after_submit(self, tmp_path):
+        outfile = tmp_path / "out.yaml"
+        s = Suite(dependency=SIMPLE_DEP, jobs=SIMPLE_JOBS)
+        s.filename = str(outfile)
+
+        counter = {"n": 0}
+
+        def fake_sp(cmd, *a, **kw):
+            counter["n"] += 1
+            return f"{counter['n']}00".encode()
+
+        with patch("subprocess.check_output", side_effect=fake_sp):
+            s.submit()
+
+        assert outfile.exists()
+        with open(outfile) as f:
+            data = yaml.safe_load(f)
+        assert "job_ids" in data
+
+    def test_submission_order_respects_dependencies(self, tmp_path):
+        s = Suite(dependency=SIMPLE_DEP, jobs=SIMPLE_JOBS)
+        s.filename = str(tmp_path / "out.yaml")
+        submitted_names = []
+        counter = {"n": 0}
+
+        def fake_sp(cmd, *a, **kw):
+            counter["n"] += 1
+            return f"{counter['n']}00".encode()
+
+        original_prepare = s.prepare_jobs
+
+        def tracking_prepare():
+            original_prepare()
+            # record the topological order from job_template
+            submitted_names.extend(s.job_template.keys())
+
+        s.prepare_jobs = tracking_prepare
+
+        with patch("subprocess.check_output", side_effect=fake_sp):
+            s.submit()
+
+        assert submitted_names.index("preprocess") < submitted_names.index("train")
+        assert submitted_names.index("train") < submitted_names.index("postprocess")
+
+    def test_dry_run_does_not_call_sbatch(self, tmp_path):
+        s = Suite(dependency=SIMPLE_DEP, jobs=SIMPLE_JOBS)
+        s.filename = str(tmp_path / "out.yaml")
+        with patch("subprocess.check_output") as mock_sp:
+            s.submit(dry_run=True)
+            mock_sp.assert_not_called()
+
+    def test_dry_run_populates_job_ids(self, tmp_path):
+        s = Suite(dependency=SIMPLE_DEP, jobs=SIMPLE_JOBS)
+        s.filename = str(tmp_path / "out.yaml")
+        s.submit(dry_run=True)
+        assert set(s.job_ids.keys()) == {"preprocess", "train", "postprocess"}
+
+
+# ---------------------------------------------------------------------------
+# graph
+# ---------------------------------------------------------------------------
+
+class TestGraph:
+    def test_returns_digraph(self):
+        import graphviz
+        s = make_suite()
+        with patch.object(s, "update_status"):
+            g = s.graph()
+        assert isinstance(g, graphviz.Digraph)
+
+    def test_node_count(self):
+        s = make_suite()
+        with patch.object(s, "update_status"):
+            g = s.graph()
+        src = str(g)
+        # One node per job
+        for name in ["preprocess", "train", "postprocess"]:
+            assert name in src
+
+    def test_edges_reflect_dependencies(self):
+        s = make_suite()
+        with patch.object(s, "update_status"):
+            g = s.graph()
+        src = str(g)
+        # preprocess -> train and train -> postprocess edges
+        assert "preprocess" in src
+        assert "train" in src
+
+
+# ---------------------------------------------------------------------------
+# update_status
+# ---------------------------------------------------------------------------
+
+class TestUpdateStatus:
+    def test_empty_job_ids_returns_empty(self):
+        s = Suite(dependency=SIMPLE_DEP)
+        result = s.update_status()
+        assert result == []
+
+    def test_returns_empty_when_sacct_missing(self):
+        s = make_suite(job_ids={"preprocess": "100"})
+        with patch("subprocess.call", side_effect=FileNotFoundError):
+            result = s.update_status()
+        assert result == []
+
+    def test_parses_sacct_output(self):
+        s = make_suite(job_ids={"preprocess": "100", "train": "200"})
+
+        sacct_output = "100|COMPLETED\n200|RUNNING\n"
+
+        with patch("subprocess.call"):
+            with patch("subprocess.check_output", return_value=sacct_output.encode()):
+                result = s.update_status()
+
+        statuses = {name: st for name, _, st in result}
+        assert statuses["preprocess"] == "COMPLETED"
+        assert statuses["train"] == "RUNNING"
+
+    def test_status_stored_on_instance(self):
+        s = make_suite(job_ids={"preprocess": "100"})
+        sacct_output = "100|PENDING\n"
+
+        with patch("subprocess.call"):
+            with patch("subprocess.check_output", return_value=sacct_output.encode()):
+                s.update_status()
+
+        assert s.status["preprocess"] == "PENDING"

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,235 @@
+import graphlib
+import pytest
+from unittest.mock import patch, MagicMock
+from io import StringIO
+
+from sworkflow.utils import (
+    as_dict,
+    as_tuple,
+    as_placeholder,
+    task_ordering,
+    check_output,
+    in_jupyter,
+    parse_array_status,
+    Default,
+)
+
+
+# ---------------------------------------------------------------------------
+# as_dict
+# ---------------------------------------------------------------------------
+
+class TestAsDict:
+    def test_linear_chain(self):
+        dep = {"B": "afterok:A"}
+        assert as_dict(dep) == {"B": ["A"]}
+
+    def test_multiple_predecessors(self):
+        dep = {"D": "afterok:B:C"}
+        result = as_dict(dep)
+        assert set(result["D"]) == {"B", "C"}
+
+    def test_keyword_stripped(self):
+        dep = {"B": "afterok:A"}
+        result = as_dict(dep)
+        assert "afterok" not in result["B"]
+
+    def test_array_suffix_stripped(self):
+        dep = {"B": "afterok:A_10"}
+        assert as_dict(dep) == {"B": ["A"]}
+
+    def test_offset_suffix_stripped(self):
+        dep = {"B": "afterok:A+1"}
+        assert as_dict(dep) == {"B": ["A"]}
+
+    def test_diamond_dag(self):
+        dep = {"B": "afterok:A", "C": "afterok:A", "D": "afterok:B:C"}
+        result = as_dict(dep)
+        assert result["B"] == ["A"]
+        assert result["C"] == ["A"]
+        assert set(result["D"]) == {"B", "C"}
+
+    def test_all_keywords_stripped(self):
+        for kw in ("after", "afterok", "afternotok", "afterany",
+                   "aftercorr", "afterburstbuffer"):
+            dep = {"B": f"{kw}:A"}
+            result = as_dict(dep)
+            assert kw not in result["B"]
+            assert "A" in result["B"]
+
+
+# ---------------------------------------------------------------------------
+# as_tuple
+# ---------------------------------------------------------------------------
+
+class TestAsTuple:
+    def test_keyword_is_first_element(self):
+        dep = {"B": "afterok:A"}
+        result = as_tuple(dep)
+        assert result["B"][0] == "afterok"
+        assert "A" in result["B"]
+
+    def test_multiple_predecessors(self):
+        dep = {"D": "afterok:B:C"}
+        result = as_tuple(dep)
+        assert result["D"][0] == "afterok"
+        assert "B" in result["D"]
+        assert "C" in result["D"]
+
+    def test_array_suffix_stripped(self):
+        dep = {"B": "afterok:A_10"}
+        result = as_tuple(dep)
+        assert "A" in result["B"]
+        assert "A_10" not in result["B"]
+
+    def test_offset_suffix_stripped(self):
+        dep = {"B": "afterok:A+1"}
+        result = as_tuple(dep)
+        assert "A" in result["B"]
+        assert "A+1" not in result["B"]
+
+
+# ---------------------------------------------------------------------------
+# as_placeholder
+# ---------------------------------------------------------------------------
+
+class TestAsPlaceholder:
+    def test_single_predecessor(self):
+        dep = {"B": "afterok:A"}
+        assert as_placeholder(dep) == {"B": "afterok:{A}"}
+
+    def test_multiple_predecessors(self):
+        dep = {"D": "afterok:B:C"}
+        result = as_placeholder(dep)
+        assert result["D"] == "afterok:{B}:{C}"
+
+    def test_array_suffix_preserved(self):
+        dep = {"B": "afterok:A_10"}
+        result = as_placeholder(dep)
+        assert result["B"] == "afterok:{A}_10"
+
+    def test_offset_suffix_preserved(self):
+        dep = {"B": "afterok:A+1"}
+        result = as_placeholder(dep)
+        assert result["B"] == "afterok:{A}+1"
+
+    def test_comma_separated_conditions(self):
+        dep = {"B": "afterok:A,afternotok:A"}
+        result = as_placeholder(dep)
+        assert "{A}" in result["B"]
+        assert result["B"] == "afterok:{A},afternotok:{A}"
+
+
+# ---------------------------------------------------------------------------
+# task_ordering
+# ---------------------------------------------------------------------------
+
+class TestTaskOrdering:
+    def test_linear_chain_order(self):
+        dep = {"B": "afterok:A", "C": "afterok:B"}
+        order = task_ordering(dep)
+        assert order.index("A") < order.index("B") < order.index("C")
+
+    def test_diamond_dag_order(self):
+        dep = {"B": "afterok:A", "C": "afterok:A", "D": "afterok:B:C"}
+        order = task_ordering(dep)
+        assert order.index("A") < order.index("B")
+        assert order.index("A") < order.index("C")
+        assert order.index("B") < order.index("D")
+        assert order.index("C") < order.index("D")
+
+    def test_all_jobs_present(self):
+        dep = {"B": "afterok:A", "C": "afterok:B"}
+        order = task_ordering(dep)
+        assert set(order) == {"A", "B", "C"}
+
+    def test_cycle_raises(self):
+        dep = {"A": "afterok:B", "B": "afterok:A"}
+        with pytest.raises(graphlib.CycleError):
+            task_ordering(dep)
+
+
+# ---------------------------------------------------------------------------
+# parse_array_status
+# ---------------------------------------------------------------------------
+
+class TestParseArrayStatus:
+    def test_non_array_entries_ignored(self):
+        mapping = {"12345": "RUNNING", "12346": "COMPLETED"}
+        result = parse_array_status(mapping)
+        assert result == {}
+
+    def test_dot_entries_ignored(self):
+        # sacct reports batch steps as jobid.batch — should be ignored
+        mapping = {"12345_1.batch": "COMPLETED"}
+        result = parse_array_status(mapping)
+        assert result == {}
+
+    def test_array_tasks_grouped(self):
+        mapping = {
+            "12345_1": "COMPLETED",
+            "12345_2": "COMPLETED",
+            "12345_3": "RUNNING",
+        }
+        result = parse_array_status(mapping)
+        assert "12345" in result
+        # should contain counts for C and R
+        summary = result["12345"]
+        assert "2C" in summary
+        assert "1R" in summary
+
+    def test_single_state(self):
+        mapping = {"99_1": "FAILED", "99_2": "FAILED"}
+        result = parse_array_status(mapping)
+        assert "99" in result
+        assert "2F" in result["99"]
+
+
+# ---------------------------------------------------------------------------
+# Default dict
+# ---------------------------------------------------------------------------
+
+class TestDefault:
+    def test_present_key_returned_normally(self):
+        d = Default({"A": "123"})
+        assert d["A"] == "123"
+
+    def test_missing_key_returns_placeholder(self):
+        d = Default()
+        assert d["foo"] == "{foo}"
+
+    def test_format_map_leaves_unknown_intact(self):
+        d = Default({"A": "111"})
+        result = "afterok:{A}:{B}".format_map(d)
+        assert result == "afterok:111:{B}"
+
+
+# ---------------------------------------------------------------------------
+# check_output (dry-run helper)
+# ---------------------------------------------------------------------------
+
+class TestCheckOutput:
+    def test_returns_bytes(self):
+        result = check_output(["sbatch", "--parsable", "job.sh"])
+        assert isinstance(result, bytes)
+
+    def test_prints_command(self, capsys):
+        check_output(["sbatch", "job.sh"])
+        out = capsys.readouterr().out
+        assert "sbatch" in out
+        assert "job.sh" in out
+
+    def test_task_name_prints_assignment(self, capsys):
+        check_output(["sbatch", "job.sh"], task_name="myjob")
+        out = capsys.readouterr().out
+        assert "myjob=" in out
+
+
+# ---------------------------------------------------------------------------
+# in_jupyter
+# ---------------------------------------------------------------------------
+
+class TestInJupyter:
+    def test_returns_false_outside_jupyter(self):
+        # In a pytest runner there is no IPython kernel
+        assert in_jupyter() is False


### PR DESCRIPTION
## Summary
- Add `tests/test_utils.py` — 31 unit tests covering all utility functions: `as_dict`, `as_tuple`, `as_placeholder`, `task_ordering`, `parse_array_status`, `Default`, `check_output`, `in_jupyter`
- Add `tests/test_suite.py` — 24 tests covering `Suite.__init__`, YAML round-trips, `prepare_jobs` flag injection, `submit` (real + dry-run), `graph`, and `update_status`
- Add `pytest` to `requirements.txt`

## No Slurm required
All `subprocess` and `sacct` calls are mocked with `unittest.mock`, so the tests run anywhere.

## Test plan
```
uv venv venv && uv pip install -e . pytest
pytest tests/ -v
# Expected: 55 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)