### PR TITLE
Add three example workflows from GöHPCoffee presentation

### DIFF
--- a/examples/afterok-afternotok/workflow.yaml
+++ b/examples/afterok-afternotok/workflow.yaml
@@ -1,0 +1,24 @@
+# Exclusive branching: afterok vs afternotok
+#
+# B depends on A succeeding.
+# C runs only if B succeeds    (afterok).
+# D runs only if B fails       (afternotok).
+#
+# Because C and D are mutually exclusive, whichever branch is not triggered
+# will remain in the Slurm queue with status DependencyNeverSatisfied.
+# You must cancel it manually: scancel <job_id>
+#
+# Demonstrates:
+#   - afterok / afternotok as mutually exclusive conditions
+#   - the DependencyNeverSatisfied gotcha and how to handle it
+
+dependency:
+  B: afterok:A
+  C: afterok:B
+  D: afternotok:B
+
+jobs:
+  A: --wrap='sleep 2'
+  B: --wrap='sleep 2'
+  C: --wrap='sleep 2'
+  D: --wrap='sleep 2'

--- a/examples/branch-merge/D.sh
+++ b/examples/branch-merge/D.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=D
+#SBATCH --output=D.out
+set -euo pipefail
+
+echo "[D] starting on $(hostname) — both B and C have completed"
+sleep 5
+echo "[D] done"

--- a/examples/branch-merge/E.sh
+++ b/examples/branch-merge/E.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+#SBATCH --job-name=E
+#SBATCH --output=E.out
+#SBATCH --mem=40G
+set -euo pipefail
+
+echo "[E] starting on $(hostname) — D has completed"
+sleep 5
+echo "[E] done"

--- a/examples/branch-merge/workflow.yaml
+++ b/examples/branch-merge/workflow.yaml
@@ -1,0 +1,23 @@
+# Branch-and-merge (diamond DAG): A -> {B, C} -> D -> E
+#
+# A fans out to B and C in parallel.
+# D waits for both B and C to succeed before starting.
+# E runs after D completes.
+#
+# Demonstrates:
+#   - fan-out (one job triggers multiple parallel jobs)
+#   - fan-in  (one job waits on multiple predecessors)
+#   - mixed job command styles: inline --wrap, plain script, script with sbatch flags
+
+dependency:
+  B: afterok:A
+  C: afterok:A
+  D: afterok:B:C
+  E: afterok:D
+
+jobs:
+  A: --wrap='sleep 2'
+  B: --wrap='sleep 2'
+  C: --wrap='sleep 2'
+  D: examples/branch-merge/D.sh
+  E: --mem=40G examples/branch-merge/E.sh

--- a/examples/job-array/workflow.yaml
+++ b/examples/job-array/workflow.yaml
@@ -1,0 +1,23 @@
+# Job array with after/afterok and minute-offset
+#
+# The 'array' job runs 5 tasks (task IDs 5, 10, 15, 20, 25).
+# B starts as soon as 'array' starts        (after  — no success check)
+# C starts when 'array' completes OK         (afterok — waits for full completion)
+# D starts 1 minute after B starts           (after:B+1 — +n means n-minute delay)
+#
+# Jobs B, C, D are not defined under 'jobs', so they use the default:
+#   sbatch --wrap="sleep 2"
+#
+# Demonstrates:
+#   - Slurm job arrays (--array)
+#   - 'after' vs 'afterok': timing vs outcome dependency
+#   - +n minute-offset syntax on a dependency
+#   - implicit default job for undefined entries
+
+dependency:
+  B: after:array
+  C: afterok:array
+  D: after:B+1
+
+jobs:
+  array: --array=5,10,15,20,25 --wrap='sleep $SLURM_ARRAY_TASK_ID'


### PR DESCRIPTION
## Summary

Adds three new runnable example directories, each taken from the GöHPCoffee
presentation "Task dependency workflow with Slurm" (Pavan Siligam, GWDG, 2022).

### `examples/branch-merge/`
Diamond DAG: A → {B, C} → D → E

- Fan-out: A triggers B and C in parallel
- Fan-in: D waits for both B and C before starting
- Mixed command styles: inline `--wrap`, plain script, script with `--mem` flag

### `examples/job-array/`
Array job (5 tasks) with `after`, `afterok`, and `+1` minute-offset

- `after:array` — B starts as soon as the array job starts (no success check)
- `afterok:array` — C waits for the array job to fully complete
- `after:B+1` — D starts 1 minute after B starts
- B, C, D have no `jobs` entry → they use the default `sbatch --wrap="sleep 2"`

### `examples/afterok-afternotok/`
Exclusive branching — one of C or D fires, never both

- C: `afterok:B` — runs if B succeeds
- D: `afternotok:B` — runs if B fails
- Illustrates the `DependencyNeverSatisfied` gotcha and the need to `scancel` the unneeded branch

## Verification
All three examples verified with `sworkflow submit --dry-run` — generated sbatch
commands and dependency flags are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)