### PR TITLE
Add MkDocs documentation site with GitHub Pages deployment

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,29 @@
+name: Deploy docs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs mkdocs-material "mkdocstrings[python]"
+          pip install -e .
+
+      - name: Deploy to GitHub Pages
+        run: mkdocs gh-deploy --force
+        # Note: griffe warns about missing type annotations but these do not
+        # affect the rendered output. --strict is intentionally omitted.

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,32 @@
+# API Reference
+
+Auto-generated from source docstrings.
+
+---
+
+## Suite
+
+The main class for defining, visualizing, and submitting a Slurm workflow.
+
+::: sworkflow.Suite
+
+---
+
+## Utilities
+
+Internal helper functions used by `Suite`. Useful if you want to integrate
+sworkflow's dependency-parsing logic into your own tooling.
+
+::: sworkflow.utils
+    options:
+      members:
+        - as_dict
+        - as_tuple
+        - as_placeholder
+        - task_ordering
+        - parse_array_status
+        - check_output
+        - in_jupyter
+        - Default
+        - load_yaml
+        - save_yaml

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,111 @@
+# CLI Reference
+
+All commands accept `-f/--filename` or the `SFILE` environment variable to specify the workflow file.
+
+```bash
+export SFILE=workflow.yaml   # set once, all commands use it
+```
+
+---
+
+## `sworkflow vis`
+
+Render the dependency graph as ASCII art.
+
+```bash
+sworkflow -f workflow.yaml vis [--rankdir LR|RL|TB|BT]
+```
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `--rankdir` | `LR` | Graph layout direction. Aliases accepted: `right`/`left`/`down`/`up` and `top`/`bottom` |
+
+**Example:**
+
+```bash
+sworkflow -f workflow.yaml vis --rankdir TB
+```
+
+---
+
+## `sworkflow submit`
+
+Submit all jobs to Slurm in dependency order. Job IDs are written back to the YAML file on completion so `status` can find them.
+
+```bash
+sworkflow -f workflow.yaml submit [--dry-run]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--dry-run` | Print the sbatch commands without executing them; uses fake job IDs |
+
+**Recommended workflow:**
+
+```bash
+sworkflow -f workflow.yaml vis            # 1. visualize
+sworkflow -f workflow.yaml submit --dry-run  # 2. check commands
+sworkflow -f workflow.yaml submit         # 3. submit for real
+```
+
+---
+
+## `sworkflow status`
+
+Query Slurm for the current state of all submitted jobs.
+
+```bash
+sworkflow -f workflow.yaml status [--vis]
+```
+
+| Option | Description |
+|--------|-------------|
+| `--vis` | Overlay job statuses on the dependency graph after printing the table |
+
+---
+
+## Dependency syntax
+
+All standard Slurm dependency conditions are supported:
+
+| Condition | Meaning |
+|-----------|---------|
+| `afterok` | Run after all predecessors complete successfully |
+| `afterany` | Run after all predecessors finish (any exit status) |
+| `afternotok` | Run after any predecessor fails |
+| `after` | Run after predecessors start (no status check) |
+| `aftercorr` | Run after corresponding array tasks complete |
+| `afterburstbuffer` | Run after burst buffer stage-out completes |
+| `singleton` | Run once no other job with the same name is running |
+
+Multiple predecessors are colon-separated: `afterok:B:C` means run after **both** B and C succeed.
+
+### Minute-offset syntax
+
+Append `+n` to delay a dependency by `n` minutes after the predecessor starts:
+
+```yaml
+dependency:
+  D: after:B+1   # D starts 1 minute after B starts
+```
+
+### Comma-separated conditions
+
+Combine multiple conditions with a comma:
+
+```yaml
+dependency:
+  D: afterok:A,afternotok:B   # D runs if A succeeds OR B fails
+```
+
+---
+
+## Troubleshooting
+
+| Problem | Fix |
+|---------|-----|
+| `command not found: sbatch` | Ensure Slurm is loaded: `module load slurm` |
+| Graphviz visualization fails | Install `graphviz` and ensure `dot` is on PATH |
+| Jobs stuck in PENDING | Check partition/account constraints; verify `--time`, `--mem`, `--account` flags |
+| `status` shows nothing | Confirm `sacct` is enabled and you have permission to query accounting data |
+| Branch stuck with `DependencyNeverSatisfied` | Cancel the unneeded branch: `scancel <job_id>` |

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -1,0 +1,159 @@
+# Examples
+
+All examples are in the `examples/` directory and can be run with `sworkflow submit` on any system with Slurm.
+
+---
+
+## Minimal — linear pipeline
+
+**Location:** `examples/minimal/`
+
+A three-job sequential pipeline: `preprocess → train → postprocess`. Each job must
+complete successfully before the next starts.
+
+```yaml title="examples/minimal/workflow.yaml"
+dependency:
+  train: afterok:preprocess
+  postprocess: afterok:train
+
+jobs:
+  preprocess: sbatch examples/minimal/preprocess.sh
+  train: sbatch examples/minimal/train.sh
+  postprocess: sbatch examples/minimal/postprocess.sh
+```
+
+```bash
+# Visualize
+sworkflow -f examples/minimal/workflow.yaml vis
+
+# Submit (dry-run first)
+sworkflow -f examples/minimal/workflow.yaml submit --dry-run
+sworkflow -f examples/minimal/workflow.yaml submit
+```
+
+**Graph:**
+
+```
+preprocess → train → postprocess
+```
+
+---
+
+## Branch and merge — diamond DAG
+
+**Location:** `examples/branch-merge/`
+
+A five-job diamond: `A` fans out to `B` and `C` in parallel, both merge into `D`, then `E` runs last.
+
+```yaml title="examples/branch-merge/workflow.yaml"
+dependency:
+  B: afterok:A
+  C: afterok:A
+  D: afterok:B:C
+  E: afterok:D
+
+jobs:
+  A: --wrap='sleep 2'
+  B: --wrap='sleep 2'
+  C: --wrap='sleep 2'
+  D: examples/branch-merge/D.sh
+  E: --mem=40G examples/branch-merge/E.sh
+```
+
+**What this demonstrates:**
+
+- **Fan-out**: `A` triggers `B` and `C` simultaneously
+- **Fan-in**: `D` waits for *both* `B` and `C` before starting (`afterok:B:C`)
+- **Mixed command styles**: inline `--wrap`, plain script, script with extra sbatch flags (`--mem=40G`)
+
+**Graph:**
+
+```
+    A
+   / \
+  B   C
+   \ /
+    D
+    |
+    E
+```
+
+---
+
+## Job array with `after`/`afterok` and minute-offset
+
+**Location:** `examples/job-array/`
+
+An array job (`array`) with 5 tasks, plus three dependent jobs that showcase
+different timing conditions.
+
+```yaml title="examples/job-array/workflow.yaml"
+dependency:
+  B: after:array
+  C: afterok:array
+  D: after:B+1
+
+jobs:
+  array: --array=5,10,15,20,25 --wrap='sleep $SLURM_ARRAY_TASK_ID'
+```
+
+**What this demonstrates:**
+
+| Job | Condition | Meaning |
+|-----|-----------|---------|
+| `B` | `after:array` | Starts as soon as `array` starts (no success check) |
+| `C` | `afterok:array` | Waits until all 5 array tasks complete successfully |
+| `D` | `after:B+1` | Starts 1 minute after `B` starts (`+n` = minute offset) |
+
+`B`, `C`, and `D` have no entry under `jobs`, so they use the default command:
+`sbatch --wrap="sleep 2"`.
+
+**Graph:**
+
+```
+array ──► B ──► D
+  │
+  └──► C
+```
+
+---
+
+## Exclusive branching — `afterok` vs `afternotok`
+
+**Location:** `examples/afterok-afternotok/`
+
+`C` and `D` are mutually exclusive: only one fires depending on whether `B` succeeds or fails.
+
+```yaml title="examples/afterok-afternotok/workflow.yaml"
+dependency:
+  B: afterok:A
+  C: afterok:B
+  D: afternotok:B
+
+jobs:
+  A: --wrap='sleep 2'
+  B: --wrap='sleep 2'
+  C: --wrap='sleep 2'
+  D: --wrap='sleep 2'
+```
+
+**What this demonstrates:**
+
+- `afterok:B` — `C` runs only if `B` exits successfully
+- `afternotok:B` — `D` runs only if `B` exits with a non-zero status
+- These two conditions are **mutually exclusive**: exactly one branch fires
+
+!!! warning "DependencyNeverSatisfied"
+    Whichever branch is not triggered will remain in the Slurm queue indefinitely
+    with status `DependencyNeverSatisfied`. Cancel it manually:
+
+    ```bash
+    scancel <job_id>
+    ```
+
+**Graph:**
+
+```
+A → B → C   (if B succeeds)
+      ↘ D   (if B fails)
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,65 @@
+# sworkflow
+
+A lightweight Python toolkit for composing, visualizing, and submitting **Slurm job workflows** with complex dependencies.
+
+Instead of writing fragile Bash scripts with nested `sbatch --dependency` calls, `sworkflow` lets you **declare dependencies** cleanly in Python or YAML, visualize them as a graph, and submit jobs in the correct order.
+
+---
+
+## Why sworkflow?
+
+Traditional Bash or "Python-flavored Bash" workflows for Slurm often suffer from:
+
+- **Fragile chaining** – manual `sbatch --dependency` wiring, brittle string parsing
+- **Hard fan-in/out** – merging branches and complex DAGs is error-prone
+- **Little validation** – cycles and typos appear late at submit/run time
+- **Poor reuse** – copy-pasted scripts with ad-hoc parameters
+
+`sworkflow` addresses this by:
+
+- **Declarative DAGs** – dependencies as data (YAML/Python), not shell glue
+- **Built-in validation** – uses `graphlib.TopologicalSorter` to prevent cycles and order jobs
+- **Visualization first** – render the DAG before submitting
+- **Consistent submission** – captures job IDs and applies dependency rules uniformly
+- **Python API + CLI** – use as a library or via simple commands
+
+---
+
+## Quick contrast
+
+=== "Bash (fragile)"
+
+    ```bash
+    jid_pre=$(sbatch --parsable preprocess.sh)
+    jid_train=$(sbatch --parsable --dependency=afterok:$jid_pre train.sh)
+    jid_post=$(sbatch --parsable --dependency=afterok:$jid_train postprocess.sh)
+
+    echo "preprocess=$jid_pre train=$jid_train postprocess=$jid_post"
+    ```
+
+=== "sworkflow (declarative)"
+
+    ```yaml
+    dependency:
+      train: afterok:preprocess
+      postprocess: afterok:train
+    jobs:
+      preprocess: preprocess.sh
+      train: train.sh
+      postprocess: postprocess.sh
+    ```
+
+---
+
+## Features
+
+- **Declarative workflow definition** – express dependencies in a dictionary or YAML file
+- **Visualization** – generate ASCII or graph-based DAGs before submission
+- **Python API & CLI** – use as a library or standalone tool
+- **Safer workflows** – prevents dependency cycles, ensures correct ordering
+- **Config-driven** – define jobs in YAML for reuse and easy editing
+
+---
+
+[Get started →](quickstart.md){ .md-button .md-button--primary }
+[Installation →](installation.md){ .md-button }

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -1,0 +1,55 @@
+# Installation
+
+## Prerequisites
+
+- Python **3.9+** (uses `graphlib.TopologicalSorter` from the standard library)
+- A working Slurm environment (`sbatch`, `squeue`, `sacct` available on PATH)
+- Optional: [Graphviz](https://graphviz.org) for PDF graph rendering
+
+## Install from source
+
+Clone the repository and install with pip:
+
+```bash
+git clone https://github.com/siligam/sworkflow.git
+cd sworkflow
+```
+
+=== "Conda (recommended for HPC)"
+
+    ```bash
+    conda env create -f environment.yaml -n sworkflow
+    conda activate sworkflow
+    pip install .
+    ```
+
+=== "Virtualenv"
+
+    ```bash
+    python3 -m venv venv
+    source venv/bin/activate
+    pip install .
+    ```
+
+## Verify the installation
+
+```bash
+sworkflow --help
+```
+
+You should see the top-level help text listing the `vis`, `submit`, and `status` subcommands.
+
+## Optional: Graphviz
+
+ASCII visualization works without Graphviz. For PDF rendering, install the system package:
+
+```bash
+# Debian / Ubuntu
+sudo apt install graphviz
+
+# macOS
+brew install graphviz
+
+# Conda
+conda install graphviz
+```

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,0 +1,145 @@
+# Quick Start
+
+## 1. Define your workflow
+
+Create a `workflow.yaml` file describing the dependencies between your jobs:
+
+```yaml
+dependency:
+  train: afterok:preprocess
+  postprocess: afterok:train
+
+jobs:
+  preprocess: preprocess.sh
+  train: train.sh
+  postprocess: postprocess.sh
+```
+
+The `dependency` section maps each job to a Slurm dependency string.
+The `jobs` section maps each job name to the shell command or script used to submit it.
+
+!!! tip
+    If a job command does not include `sbatch`, it is prepended automatically.
+    You can pass raw `sbatch` flags directly, e.g. `--mem=40G my_script.sh`.
+
+## 2. Visualize the graph
+
+Before submitting, render the dependency graph to verify it looks correct:
+
+```bash
+sworkflow -f workflow.yaml vis
+```
+
+Output:
+
+```
+preprocess
+   |
+ train
+   |
+postprocess
+```
+
+## 3. Dry-run
+
+Check the exact `sbatch` commands that will be generated without running anything:
+
+```bash
+sworkflow -f workflow.yaml submit --dry-run
+```
+
+Output:
+
+```
+preprocess=$(sbatch --parsable preprocess.sh)
+train=$(sbatch --parsable --dependency=afterok:{preprocess} train.sh)
+postprocess=$(sbatch --parsable --dependency=afterok:{train} postprocess.sh)
+```
+
+## 4. Submit
+
+```bash
+sworkflow -f workflow.yaml submit
+```
+
+Job IDs are printed and written back to `workflow.yaml` so `status` can find them later.
+
+## 5. Check status
+
+```bash
+sworkflow -f workflow.yaml status
+```
+
+## Using the `SFILE` environment variable
+
+Set `SFILE` once to avoid repeating `-f workflow.yaml` on every command:
+
+```bash
+export SFILE=workflow.yaml
+sworkflow vis
+sworkflow submit --dry-run
+sworkflow submit
+sworkflow status
+```
+
+---
+
+## YAML schema
+
+```yaml
+dependency:        # map[job] -> "<condition>:<dep1>[:<dep2>...]"
+  train: afterok:preprocess
+  eval: afterany:train:postprocess
+
+jobs:              # map[job] -> shell command or path to script
+  preprocess: preprocess.sh
+  train: train.sh
+  postprocess: postprocess.sh
+```
+
+See [Dependency syntax](cli.md#dependency-syntax) for the full list of supported conditions.
+
+---
+
+## Python API
+
+You can also define and run workflows entirely in Python:
+
+```python
+import sworkflow
+
+dependency = {
+    "train": "afterok:preprocess",
+    "postprocess": "afterok:train",
+}
+
+jobs = {
+    "preprocess": "preprocess.sh",
+    "train": "train.sh",
+    "postprocess": "postprocess.sh",
+}
+
+suite = sworkflow.Suite(dependency, jobs)
+
+suite.visualize(as_ascii=True)      # print ASCII graph
+suite.submit()                       # submit; saves job IDs to submit.yaml
+suite.update_status()                # query sacct for current state
+```
+
+### Reload a submitted workflow
+
+After `submit()`, job IDs are persisted to the YAML file. Reload it later to check status:
+
+```python
+suite = sworkflow.Suite.load_yaml("submit.yaml")
+suite.update_status()
+print(suite.status)
+```
+
+### Load from YAML
+
+```python
+suite = sworkflow.Suite.load_yaml("workflow.yaml")
+suite.visualize()
+suite.submit()
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,60 @@
+site_name: sworkflow
+site_description: A lightweight Python toolkit for composing, visualizing, and submitting Slurm job workflows with complex dependencies.
+site_author: Pavan Siligam
+site_url: https://siligam.github.io/sworkflow/
+
+repo_url: https://github.com/siligam/sworkflow
+repo_name: siligam/sworkflow
+
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+  features:
+    - navigation.tabs
+    - navigation.sections
+    - navigation.top
+    - content.code.copy
+    - content.code.annotate
+
+plugins:
+  - search
+  - mkdocstrings:
+      handlers:
+        python:
+          options:
+            docstring_style: google
+            show_source: true
+            show_root_heading: true
+            show_symbol_type_heading: true
+            members_order: source
+
+nav:
+  - Home: index.md
+  - Installation: installation.md
+  - Quick Start: quickstart.md
+  - CLI Reference: cli.md
+  - Examples: examples.md
+  - API Reference: api.md
+
+markdown_extensions:
+  - admonition
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - tables
+  - toc:
+      permalink: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,6 @@ graphlib_backport; python_version < "3.9.0"
 requests
 click
 pytest
+mkdocs
+mkdocs-material
+mkdocstrings[python]


### PR DESCRIPTION
## Summary

Sets up a full documentation site using MkDocs with the Material theme and `mkdocstrings` for auto-generated API reference.

### Site pages

| Page | Content |
|------|---------|
| **Home** | Landing page — Why/Features/Bash-vs-YAML contrast |
| **Installation** | Conda + virtualenv instructions |
| **Quick Start** | Workflow YAML, vis/submit/status steps, Python API |
| **CLI Reference** | Full flag tables, dependency syntax, troubleshooting |
| **Examples** | All four examples with YAML snippets and ASCII diagrams |
| **API Reference** | Auto-generated from Google-style docstrings on `Suite` and `utils` |

### Infrastructure

- `mkdocs.yml` — Material theme with tabs, code copy, dark mode toggle
- `.github/workflows/docs.yml` — deploys to `gh-pages` branch on every push to `main`
- `requirements.txt` — adds `mkdocs`, `mkdocs-material`, `mkdocstrings[python]`

### After merging

Enable GitHub Pages in repo **Settings → Pages → Source: `gh-pages` branch / root**.

The site will be live at: **https://siligam.github.io/sworkflow/**

## Test plan
- [x] `mkdocs build` completes without errors locally
- [ ] GitHub Actions deploys successfully after merge
- [ ] GitHub Pages enabled and site is accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)